### PR TITLE
Locale fix

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -226,17 +226,18 @@ function MonDKP:CheckOfficer()      -- checks if user is an officer IF core.IsOf
 end
 
 function MonDKP:GetGuildRankGroup(index)                -- returns all members within a specific rank index as well as their index in the guild list (for use with GuildRosterSetPublicNote(index, "msg") and GuildRosterSetOfficerNote)
-  local name, rank, note;                               -- local temp = MonDKP:GetGuildRankGroup(1)
+  local name, rank, seed;                               -- local temp = MonDKP:GetGuildRankGroup(1)
   local group = {}                                      -- print(temp[1]["name"])
   local guildSize,_,_ = GetNumGuildMembers();
 
   if IsInGuild() then
     for i=1, tonumber(guildSize) do
-      name,_,rank,_,_,_,note = GetGuildRosterInfo(i)
+      name,_,rank = GetGuildRosterInfo(i)
+	  seed = MonDKP:RosterSeedExtract(i)
       rank = rank+1;
       name = strsub(name, 1, string.find(name, "-")-1)  -- required to remove server name from player (can remove in classic if this is not an issue)
       if rank == index then
-        tinsert(group, { name = name, index = i, note = note })
+        tinsert(group, { name = name, index = i, seed = seed })
       end
     end
     return group;
@@ -278,10 +279,11 @@ end
 
 function MonDKP:UpdateSeeds()		-- updates seeds on leaders note as well as all 3 tables
 	local leader = MonDKP:GetGuildRankGroup(1)
-	GuildRosterSetPublicNote(leader[1].index, curTime)
-	MonDKP_DKPTable.seed = curTime
-	MonDKP_DKPHistory.seed = curTime
-	MonDKP_Loot.seed = curTime
+	local seed = MonDKP:RosterSeedUpdate(leader[1].index)
+	
+	MonDKP_DKPTable.seed = seed
+	MonDKP_DKPHistory.seed = seed
+	MonDKP_Loot.seed = seed
 end
 
 function MonDKP:GetPlayerDKP(player)

--- a/Core.lua
+++ b/Core.lua
@@ -9,31 +9,36 @@ local _G = _G;
 core.MonDKP = {};       -- UI Frames global
 local MonDKP = core.MonDKP;
 
+local tc_colors = {
+	["Druid"] = { r = 1, g = 0.49, b = 0.04, hex = "FF7D0A" },
+	["Hunter"] = {  r = 0.67, g = 0.83, b = 0.45, hex = "ABD473" },
+	["Mage"] = { r = 0.25, g = 0.78, b = 0.92, hex = "40C7EB" },
+	["Priest"] = { r = 1, g = 1, b = 1, hex = "FFFFFF" },
+	["Rogue"] = { r = 1, g = 0.96, b = 0.41, hex = "FFF569" },
+	["Shaman"] = { r = 0.96, g = 0.55, b = 0.73, hex = "F58CBA" },
+	["Paladin"] = { r = 0.96, g = 0.55, b = 0.73, hex = "F58CBA" },
+	["Warlock"] = { r = 0.53, g = 0.53, b = 0.93, hex = "8787ED" },
+	["Warrior"] = { r = 0.78, g = 0.61, b = 0.43, hex = "C79C6E" }
+}
+
+local tc_classes = {}
+
 core.faction = UnitFactionGroup("player")
 if core.faction == "Horde" then
-  core.CColors = {   -- class colors
-    ["Druid"] = { r = 1, g = 0.49, b = 0.04, hex = "FF7D0A" },
-    ["Hunter"] = {  r = 0.67, g = 0.83, b = 0.45, hex = "ABD473" },
-    ["Mage"] = { r = 0.25, g = 0.78, b = 0.92, hex = "40C7EB" },
-    ["Priest"] = { r = 1, g = 1, b = 1, hex = "FFFFFF" },
-    ["Rogue"] = { r = 1, g = 0.96, b = 0.41, hex = "FFF569" },
-    ["Shaman"] = { r = 0.96, g = 0.55, b = 0.73, hex = "F58CBA" },
-    ["Warlock"] = { r = 0.53, g = 0.53, b = 0.93, hex = "8787ED" },
-    ["Warrior"] = { r = 0.78, g = 0.61, b = 0.43, hex = "C79C6E" }
-  }
-  core.classes = { "Druid", "Hunter", "Mage", "Priest", "Rogue", "Shaman", "Warlock", "Warrior" }
+  tc_classes = { "Druid", "Hunter", "Mage", "Priest", "Rogue", "Shaman", "Warlock", "Warrior" }
 elseif core.faction == "Alliance" then
-  core.CColors = {   -- class colors
-    ["Druid"] = { r = 1, g = 0.49, b = 0.04, hex = "FF7D0A" },
-    ["Hunter"] = {  r = 0.67, g = 0.83, b = 0.45, hex = "ABD473" },
-    ["Mage"] = { r = 0.25, g = 0.78, b = 0.92, hex = "40C7EB" },
-    ["Paladin"] = { r = 0.96, g = 0.55, b = 0.73, hex = "F58CBA" },
-    ["Priest"] = { r = 1, g = 1, b = 1, hex = "FFFFFF" },
-    ["Rogue"] = { r = 1, g = 0.96, b = 0.41, hex = "FFF569" },
-    ["Warlock"] = { r = 0.53, g = 0.53, b = 0.93, hex = "8787ED" },
-    ["Warrior"] = { r = 0.78, g = 0.61, b = 0.43, hex = "C79C6E" }
-  }
-  core.classes = { "Druid", "Hunter", "Mage", "Paladin", "Priest", "Rogue", "Warlock", "Warrior" }
+  tc_classes = { "Druid", "Hunter", "Mage", "Paladin", "Priest", "Rogue", "Warlock", "Warrior" }
+end
+
+core.CColors = {
+	["UNKNOWN"] = { r = 0.627, g = 0.627, b = 0.627, hex = "A0A0A0" }
+}
+core.classes = {}
+for i = 1, #tc_classes do
+	local cname = tc_classes[i]
+	local lname = string.upper(cname)
+	core.CColors[lname] = tc_colors[cname]
+	table.insert(core.classes, lname)
 end
 
 --------------------------------------
@@ -131,7 +136,12 @@ core.CurView = "all"
 
 function MonDKP:GetCColors(class)
   if core.CColors then 
-    local c = core.CColors[class] or core.CColors;
+	local c
+    if class then
+		c = core.CColors[class] or core.CColors["UNKNOWN"];
+	else
+		c = core.CColors
+	end
     return c;
   else
     return false;
@@ -238,9 +248,35 @@ function MonDKP:GetThemeColor()
   return c;
 end
 
-function MonDKP:UpdateSeeds()		-- updates seeds on leaders note as well as all 3 tables
-	local curTime = time()
+function MonDKP:GenerateSeed()
+	local seed = tonumber(date("!%y%m%d%H%M%S")) -- using utc times instead of time()
+	return seed
+end
 
+function MonDKP:RosterSeedUpdate(index)
+	local oldseed, note = MonDKP:RosterSeedExtract(index)
+	local newseed = MonDKP:GenerateSeed()
+	local textseed = "{MonDKP=" .. tostring(newseed) .. "}"
+	if oldseed > 0 then
+	    note = string.gsub(note, "{MonDKP=(%d+)}", textseed)
+	else
+	    note = note .. " " .. textseed
+	end
+	GuildRosterSetPublicNote(index, note)
+	return newseed
+end
+
+function MonDKP:RosterSeedExtract(index)
+	local seed, note
+	_,_,_,_,_,_,note = GetGuildRosterInfo(index)
+	seed = string.match(note, "{MonDKP=(%d+)}")
+	if not seed then
+	    seed = 0
+    end
+	return tonumber(seed), note
+end
+
+function MonDKP:UpdateSeeds()		-- updates seeds on leaders note as well as all 3 tables
 	local leader = MonDKP:GetGuildRankGroup(1)
 	GuildRosterSetPublicNote(leader[1].index, curTime)
 	MonDKP_DKPTable.seed = curTime
@@ -250,7 +286,6 @@ end
 
 function MonDKP:GetPlayerDKP(player)
   local search = MonDKP:Table_Search(MonDKP_DKPTable, player)
-  local dkp;
 
   if search then
     return MonDKP_DKPTable[search[1][1]].dkp

--- a/Modules/AdjustDKP.lua
+++ b/Modules/AdjustDKP.lua
@@ -7,7 +7,7 @@ local curReason;
 local function AdjustDKP()
 	local adjustReason = curReason;
 	local c = MonDKP:GetCColors();
-	local date = time()
+	local curTime = time()
 
 	if (curReason == "Other") then adjustReason = "Other - "..MonDKP.ConfigTab2.otherReason:GetText(); end
 	if curReason == "Boss Kill Bonus" then adjustReason = core.CurrentRaidZone..": "..core.LastKilledBoss; end
@@ -33,14 +33,14 @@ local function AdjustDKP()
 								MonDKP:DKPTable_Set(core.SelectedData[i]["player"], "dkp", MonDKP.ConfigTab2.addDKP:GetNumber(), false)
 						end
 					end
-					tinsert(MonDKP_DKPHistory, {players=dkpHistoryString, dkp=MonDKP.ConfigTab2.addDKP:GetNumber(), reason=adjustReason, date=date})
+					tinsert(MonDKP_DKPHistory, {players=dkpHistoryString, dkp=MonDKP.ConfigTab2.addDKP:GetNumber(), reason=adjustReason, date=curTime})
 					MonDKP.Sync:SendData("MonDKPDataSync", MonDKP_DKPTable)         -- broadcast updated DKP table
 					if MonDKP.ConfigTab6.history then
 						MonDKP:DKPHistory_Reset()
 					end
 					MonDKP:DKPHistory_Update()
 					local temp_table = {}
-					tinsert(temp_table, {seed = MonDKP_DKPHistory.seed, {players=dkpHistoryString, dkp=MonDKP.ConfigTab2.addDKP:GetNumber(), reason=adjustReason, date=date}})
+					tinsert(temp_table, {seed = MonDKP_DKPHistory.seed, {players=dkpHistoryString, dkp=MonDKP.ConfigTab2.addDKP:GetNumber(), reason=adjustReason, date=curTime}})
 					MonDKP.Sync:SendData("MonDKPDKPAward", temp_table[1])
 					table.wipe(temp_table)
 					if (MonDKP.ConfigTab1.checkBtn[10]:GetChecked() and MonDKP.ConfigTab2.selectAll:GetChecked()) then
@@ -71,7 +71,7 @@ local function AdjustDKP()
 						MonDKP:DKPTable_Set(core.SelectedData[i]["player"], "dkp", MonDKP.ConfigTab2.addDKP:GetNumber(), false)
 				end
 			end
-			tinsert(MonDKP_DKPHistory, {players=dkpHistoryString, dkp=MonDKP.ConfigTab2.addDKP:GetNumber(), reason=adjustReason, date=date})
+			tinsert(MonDKP_DKPHistory, {players=dkpHistoryString, dkp=MonDKP.ConfigTab2.addDKP:GetNumber(), reason=adjustReason, date=curTime})
 			MonDKP:UpdateSeeds()
 			MonDKP.Sync:SendData("MonDKPDataSync", MonDKP_DKPTable)         -- broadcast updated DKP table
 			if MonDKP.ConfigTab6.history then
@@ -79,7 +79,7 @@ local function AdjustDKP()
 			end
 			MonDKP:DKPHistory_Update()
 			local temp_table = {}
-			tinsert(temp_table, {seed = MonDKP_DKPHistory.seed, {players=dkpHistoryString, dkp=MonDKP.ConfigTab2.addDKP:GetNumber(), reason=adjustReason, date=date}})
+			tinsert(temp_table, {seed = MonDKP_DKPHistory.seed, {players=dkpHistoryString, dkp=MonDKP.ConfigTab2.addDKP:GetNumber(), reason=adjustReason, date=curTime}})
 			MonDKP.Sync:SendData("MonDKPDKPAward", temp_table[1])
 			table.wipe(temp_table)
 			if (MonDKP.ConfigTab1.checkBtn[10]:GetChecked() and MonDKP.ConfigTab2.selectAll:GetChecked()) then
@@ -131,6 +131,7 @@ end
 
 local function DecayDKP(amount, deductionType, GetSelections)
 	local playerString = "";
+	local curTime = time()
 
 	MonDKP:SeedVerify_Update()
 	if core.UpToDate == false and core.IsOfficer == true then
@@ -173,14 +174,14 @@ local function DecayDKP(amount, deductionType, GetSelections)
 
 				if tonumber(amount) < 0 then amount = amount * -1 end		-- flips value to positive if officer accidently used a negative number
 
-				tinsert(MonDKP_DKPHistory, {players=playerString, dkp="-"..amount.."%", reason="Weekly Decay", date=time()})
+				tinsert(MonDKP_DKPHistory, {players=playerString, dkp="-"..amount.."%", reason="Weekly Decay", date=curTime})
 				MonDKP.Sync:SendData("MonDKPDataSync", MonDKP_DKPTable)         -- broadcast updated DKP table
 				if MonDKP.ConfigTab6.history then
 					MonDKP:DKPHistory_Reset()
 				end
 				MonDKP:DKPHistory_Update()
 				local temp_table = {}
-				tinsert(temp_table, {seed = MonDKP_DKPHistory.seed, {players=playerString, dkp="-"..amount.."%", reason="Weekly Decay", date=time()}})
+				tinsert(temp_table, {seed = MonDKP_DKPHistory.seed, {players=playerString, dkp="-"..amount.."%", reason="Weekly Decay", date=curTime}})
 				MonDKP.Sync:SendData("MonDKPDKPAward", temp_table[1])
 				table.wipe(temp_table)
 				DKPTable_Update()
@@ -226,7 +227,7 @@ local function DecayDKP(amount, deductionType, GetSelections)
 
 		if tonumber(amount) < 0 then amount = amount * -1 end		-- flips value to positive if officer accidently used a negative number
 
-		tinsert(MonDKP_DKPHistory, {players=playerString, dkp="-"..amount.."%", reason="Weekly Decay", date=time()})
+		tinsert(MonDKP_DKPHistory, {players=playerString, dkp="-"..amount.."%", reason="Weekly Decay", date=curTime})
 		MonDKP:UpdateSeeds()
 		MonDKP.Sync:SendData("MonDKPDataSync", MonDKP_DKPTable)         -- broadcast updated DKP table
 		if MonDKP.ConfigTab6.history then
@@ -234,7 +235,7 @@ local function DecayDKP(amount, deductionType, GetSelections)
 		end
 		MonDKP:DKPHistory_Update()
 		local temp_table = {}
-		tinsert(temp_table, {seed = MonDKP_DKPHistory.seed, {players=playerString, dkp="-"..amount.."%", reason="Weekly Decay", date=time()}})
+		tinsert(temp_table, {seed = MonDKP_DKPHistory.seed, {players=playerString, dkp="-"..amount.."%", reason="Weekly Decay", date=curTime}})
 		MonDKP.Sync:SendData("MonDKPDKPAward", temp_table[1])
 		table.wipe(temp_table)
 		DKPTable_Update()

--- a/Modules/Bidding.lua
+++ b/Modules/Bidding.lua
@@ -505,7 +505,7 @@ local function AwardItem()
 						MonDKP:LootHistory_Reset();
 						MonDKP:LootHistory_Update("No Filter")
 						local leader = MonDKP:GetGuildRankGroup(1)
-						GuildRosterSetPublicNote(leader[1].index, time())
+						MonDKP:RosterSeedUpdate(leader[1].index)
 						MonDKP.Sync:SendData("MonDKPDataSync", MonDKP_DKPTable)
 						MonDKP.Sync:SendData("MonDKPLootAward", temp_table[1])
 
@@ -605,7 +605,7 @@ local function AwardItem()
 				MonDKP:LootHistory_Reset();
 				MonDKP:LootHistory_Update("No Filter")
 				local leader = MonDKP:GetGuildRankGroup(1)
-				GuildRosterSetPublicNote(leader[1].index, time())
+				MonDKP:RosterSeedUpdate(leader[1].index)
 				MonDKP.Sync:SendData("MonDKPDataSync", MonDKP_DKPTable)
 				MonDKP.Sync:SendData("MonDKPLootAward", temp_table[1])
 

--- a/Modules/Bidding.lua
+++ b/Modules/Bidding.lua
@@ -92,7 +92,7 @@ function MonDKP_CHAT_MSG_WHISPER(text, ...)
 				SendChatMessage(response, "WHISPER", nil, name)
 				return
 			end
-			if (tonumber(cmd) and (tonumber(cmd) <= MonDKP_DB.modes.MaximumBid or MonDKP_DB.modes.MaximumBid == 0)) or ((mode == "Static Item Values" or (mode == "Zero Sum" and MonDKP_DB.modes.ZeroSumBidType == "Static")) and not cmd) then
+			if (tonumber(cmd) and (MonDKP_DB.modes.MaximumBid == nil or tonumber(cmd) <= MonDKP_DB.modes.MaximumBid or MonDKP_DB.modes.MaximumBid == 0)) or ((mode == "Static Item Values" or (mode == "Zero Sum" and MonDKP_DB.modes.ZeroSumBidType == "Static")) and not cmd) then
 				if dkp then
 					if not MonDKP_DB.modes.SubZeroBidding then MonDKP_DB.modes.SubZeroBidding = false end
 					if (cmd and cmd <= dkp) or (MonDKP_DB.modes.SubZeroBidding == true and dkp >= 0) or (mode == "Static Item Values" and dkp > 0 and (dkp > core.BiddingWindow.cost:GetNumber() or MonDKP_DB.modes.SubZeroBidding == true or MonDKP_DB.modes.costvalue == "Percent")) or ((mode == "Zero Sum" and MonDKP_DB.modes.ZeroSumBidType == "Static") and not cmd) then

--- a/Modules/Bidding.lua
+++ b/Modules/Bidding.lua
@@ -459,7 +459,7 @@ end
 local function AwardItem()
 	local cost;
 	local winner;
-	local date;
+	local curTime;
 	local selected;
 
 	MonDKP:SeedVerify_Update()
@@ -472,7 +472,7 @@ local function AwardItem()
 				if SelectedBidder["player"] then
 					cost = core.BiddingWindow.cost:GetNumber();
 					winner = SelectedBidder["player"];
-					date = time()
+					curTime = time()
 					
 					if MonDKP_DB.modes.costvalue == "Percent" then
 						if MonDKP_DB.modes.mode == "Roll Based Bidding" then
@@ -499,9 +499,9 @@ local function AwardItem()
 					  OnAccept = function()
 						SendChatMessage("Congrats "..winner.." on "..CurrItemForBid.." @ "..cost.." DKP", "RAID_WARNING")
 						MonDKP:DKPTable_Set(winner, "dkp", MonDKP_round(-cost, MonDKP_DB.modes.rounding), true)
-						tinsert(MonDKP_Loot, {player=winner, loot=CurrItemForBid, zone=core.CurrentRaidZone, date=date, boss=core.LastKilledBoss, cost=cost})
+						tinsert(MonDKP_Loot, {player=winner, loot=CurrItemForBid, zone=core.CurrentRaidZone, date=curTime, boss=core.LastKilledBoss, cost=cost})
 						local temp_table = {}
-						tinsert(temp_table, {seed = MonDKP_Loot.seed, {player=winner, loot=CurrItemForBid, zone=core.CurrentRaidZone, date=date, boss=core.LastKilledBoss, cost=cost}})
+						tinsert(temp_table, {seed = MonDKP_Loot.seed, {player=winner, loot=CurrItemForBid, zone=core.CurrentRaidZone, date=curTime, boss=core.LastKilledBoss, cost=cost}})
 						MonDKP:LootHistory_Reset();
 						MonDKP:LootHistory_Update("No Filter")
 						local leader = MonDKP:GetGuildRankGroup(1)
@@ -571,7 +571,7 @@ local function AwardItem()
 		if SelectedBidder["player"] then
 			cost = core.BiddingWindow.cost:GetNumber();
 			winner = SelectedBidder["player"];
-			date = time()
+			curTime = time()
 			
 			if MonDKP_DB.modes.costvalue == "Percent" then
 				if MonDKP_DB.modes.mode == "Roll Based Bidding" then
@@ -598,10 +598,10 @@ local function AwardItem()
 			  OnAccept = function()
 				SendChatMessage("Congrats "..winner.." on "..CurrItemForBid.." @ "..cost.." DKP", "RAID_WARNING")
 				MonDKP:DKPTable_Set(winner, "dkp", MonDKP_round(-cost, MonDKP_DB.modes.rounding), true)
-				tinsert(MonDKP_Loot, {player=winner, loot=CurrItemForBid, zone=core.CurrentRaidZone, date=date, boss=core.LastKilledBoss, cost=cost})
+				tinsert(MonDKP_Loot, {player=winner, loot=CurrItemForBid, zone=core.CurrentRaidZone, date=curTime, boss=core.LastKilledBoss, cost=cost})
 				MonDKP:UpdateSeeds()
 				local temp_table = {}
-				tinsert(temp_table, {seed = MonDKP_Loot.seed, {player=winner, loot=CurrItemForBid, zone=core.CurrentRaidZone, date=date, boss=core.LastKilledBoss, cost=cost}})
+				tinsert(temp_table, {seed = MonDKP_Loot.seed, {player=winner, loot=CurrItemForBid, zone=core.CurrentRaidZone, date=curTime, boss=core.LastKilledBoss, cost=cost}})
 				MonDKP:LootHistory_Reset();
 				MonDKP:LootHistory_Update("No Filter")
 				local leader = MonDKP:GetGuildRankGroup(1)

--- a/Modules/ManageEntries.lua
+++ b/Modules/ManageEntries.lua
@@ -87,7 +87,7 @@ function AddRaidToDKPTable()
 		end
 
 		for i=1, GroupSize do
-			tempName,_,_,_,tempClass = GetRaidRosterInfo(i)
+			tempName,_,_,_,_,tempClass = GetRaidRosterInfo(i)
 			for j=1, guildSize do
 				name = GetGuildRosterInfo(j)
 				name = strsub(name, 1, string.find(name, "-")-1)						-- required to remove server name from player (can remove in classic if this is not an issue)
@@ -145,7 +145,7 @@ local function AddGuildToDKPTable(rank)
 	local numPlayers = 0;
 
 	for i=1, guildSize do
-		name,_,rankIndex,_,class = GetGuildRosterInfo(i)
+		name,_,rankIndex,_,_,_,_,_,_,_,class = GetGuildRosterInfo(i)
 		name = strsub(name, 1, string.find(name, "-")-1)			-- required to remove server name from player (can remove in classic if this is not an issue)
 		local search = MonDKP:Table_Search(MonDKP_DKPTable, name)
 
@@ -180,10 +180,10 @@ end
 
 local function AddTargetToDKPTable()
 	local name = UnitName("target");
-	local class = UnitClass("target");
+	local _,class = UnitClass("target");
 	local c;
 
-	local search = MonDKP:Table_Search(MonDKP_DKPTable, UnitName("target"))
+	local search = MonDKP:Table_Search(MonDKP_DKPTable, name)
 
 	if not search then
 		tinsert(MonDKP_DKPTable, {

--- a/Modules/ZeroSumBank.lua
+++ b/Modules/ZeroSumBank.lua
@@ -4,7 +4,7 @@ local MonDKP = core.MonDKP;
 
 local function ZeroSumDistribution()
 	if IsInRaid() then
-		local date = time();
+		local curTime = time();
 		local distribution;
 		local reason = MonDKP_DB.bossargs.CurrentRaidZone..": "..MonDKP_DB.bossargs.LastKilledBoss
 		local players = "";
@@ -39,14 +39,14 @@ local function ZeroSumDistribution()
 		end
 
 		MonDKP:UpdateSeeds()
-		tinsert(MonDKP_DKPHistory, {players=players, dkp=distribution, reason=reason, date=date})
+		tinsert(MonDKP_DKPHistory, {players=players, dkp=distribution, reason=reason, date=curTime})
 		MonDKP.Sync:SendData("MonDKPDataSync", MonDKP_DKPTable)
 		if MonDKP.ConfigTab6.history then
 			MonDKP:DKPHistory_Reset()
 		end
 		MonDKP:DKPHistory_Update()
 		local temp_table = {}
-		tinsert(temp_table, {seed = MonDKP_DKPHistory.seed, {players=players, dkp=distribution, reason=reason, date=date}})
+		tinsert(temp_table, {seed = MonDKP_DKPHistory.seed, {players=players, dkp=distribution, reason=reason, date=curTime}})
 		MonDKP.Sync:SendData("MonDKPDKPAward", temp_table[1])
 		table.wipe(temp_table)
 		MonDKP.Sync:SendData("MonDKPBroadcast", "Raid DKP Adjusted by "..distribution.." among "..#VerifyTable.." players for reason: "..reason)

--- a/Modules/comm.lua
+++ b/Modules/comm.lua
@@ -100,7 +100,7 @@ function MonDKP.Sync:OnCommReceived(prefix, message, distribution, sender)
 						local leader = MonDKP:GetGuildRankGroup(1)
 
 						if (prefix == "MonDKPLogSync") then
-							if tonumber(leader[1].note) > deserialized.seed and core.IsOfficer == true then
+							if leader[1].seed > deserialized.seed and core.IsOfficer == true then
 								StaticPopupDialogs["CONFIRM_HIST_BCAST1"] = {
 									text = "|CFFFF0000WARNING|r: "..sender.." has broadcast an out of date Loot History Table. This can cause irreversable damage to your Loot History table. Would you like to accept?",
 									button1 = "Yes",
@@ -126,7 +126,7 @@ function MonDKP.Sync:OnCommReceived(prefix, message, distribution, sender)
 								MonDKP:Print("Loot history update complete.")
 							end
 						elseif prefix == "MonDKPLootAward" then
-							if tonumber(leader[1].note) > deserialized.seed and core.IsOfficer == true then
+							if leader[1].seed > deserialized.seed and core.IsOfficer == true then
 								StaticPopupDialogs["CONFIRM_LOOT_AWARD_BCAST"] = {
 									text = "|CFFFF0000WARNING|r: "..sender.." has broadcast an entry from out of date DKP History Table. This can cause irreversable damage to your DKP History table. Would you like to accept?",
 									button1 = "Yes",
@@ -151,7 +151,7 @@ function MonDKP.Sync:OnCommReceived(prefix, message, distribution, sender)
 								MonDKP:LootHistory_Update("No Filter")
 							end
 						elseif prefix == "MonDKPDKPAward" then
-							if tonumber(leader[1].note) > deserialized.seed and core.IsOfficer == true then
+							if leader[1].seed > deserialized.seed and core.IsOfficer == true then
 								StaticPopupDialogs["CONFIRM_DKP_AWARD_BCAST"] = {
 									text = "|CFFFF0000WARNING|r: "..sender.." has broadcast an entry from out of date DKP History Table. This can cause irreversable damage to your DKP History table. Would you like to accept?",
 									button1 = "Yes",
@@ -180,7 +180,7 @@ function MonDKP.Sync:OnCommReceived(prefix, message, distribution, sender)
 		      					MonDKP:DKPHistory_Update()
 		      				end
 						elseif prefix == "MonDKPDKPLogSync" then
-							if tonumber(leader[1].note) > deserialized.seed and core.IsOfficer == true then
+							if leader[1].seed > deserialized.seed and core.IsOfficer == true then
 								StaticPopupDialogs["CONFIRM_HIST_BCAST2"] = {
 									text = "|CFFFF0000WARNING|r: "..sender.." has broadcast an out of date DKP History Table. This can cause irreversable damage to your DKP History table. Would you like to accept?",
 									button1 = "Yes",
@@ -210,7 +210,7 @@ function MonDKP.Sync:OnCommReceived(prefix, message, distribution, sender)
 								MonDKP:Print("DKP history update complete.")
 							end
 						elseif prefix == "MonDKPDeleteLoot" then
-							if tonumber(leader[1].note) > deserialized.seed and core.IsOfficer == true then
+							if leader[1].seed > deserialized.seed and core.IsOfficer == true then
 								StaticPopupDialogs["CONFIRM_LOOT_BCAST1"] = {
 									text = "|CFFFF0000WARNING|r: "..sender.." has deleted an item from an outdated Loot History table. This could cause the wrong item in your table to be deleted. Would you like to accept?",
 									button1 = "Yes",
@@ -238,7 +238,7 @@ function MonDKP.Sync:OnCommReceived(prefix, message, distribution, sender)
 								MonDKP:LootHistory_Update("No Filter");
 							end
 						elseif prefix == "MonDKPEditLoot" then
-							if tonumber(leader[1].note) > deserialized.seed and core.IsOfficer == true then
+							if leader[1].seed > deserialized.seed and core.IsOfficer == true then
 								StaticPopupDialogs["CONFIRM_LOOT_ADJUST_BCAST"] = {
 									text = "|CFFFF0000WARNING|r: "..sender.." has attempted to update an item from an out of date Loot Table. This can cause irreversable damage to your DKP table. Would you like to accept?",
 									button1 = "Yes",
@@ -272,7 +272,7 @@ function MonDKP.Sync:OnCommReceived(prefix, message, distribution, sender)
 								DKPTable_Update()
 							end
 						elseif prefix == "MonDKPDKPDelSync" then
-							if tonumber(leader[1].note) > deserialized.seed and core.IsOfficer == true then
+							if leader[1].seed > deserialized.seed and core.IsOfficer == true then
 								StaticPopupDialogs["CONFIRM_DKP_DELETE_BCAST"] = {
 									text = "|CFFFF0000WARNING|r: "..sender.." has attempted to delete an item from an out of date DKP history Table. This can cause irreversable damage to your DKP table. Would you like to accept?",
 									button1 = "Yes",
@@ -345,7 +345,7 @@ function MonDKP.Sync:OnCommReceived(prefix, message, distribution, sender)
 							}
 							StaticPopup_Show ("SEND_MODES")
 						else
-							if tonumber(leader[1].note) > deserialized.seed and core.IsOfficer == true then
+							if leader[1].seed > deserialized.seed and core.IsOfficer == true then
 								StaticPopupDialogs["CONFIRM_DKP_BROADCAST"] = {
 									text = "|CFFFF0000WARNING|r: "..sender.." has broadcast an out of date DKP Table. This can cause irreversable damage to your DKP table. Would you like to accept?",
 									button1 = "Yes",

--- a/MonolithDKP.lua
+++ b/MonolithDKP.lua
@@ -48,7 +48,7 @@ function MonDKP:FilterDKPTable(sort, reset)          -- filters core.WorkingTabl
     if(core.classFiltered[MonDKP_DKPTable[k]["class"]] == true) then
       if MonDKP.ConfigTab1.checkBtn[10]:GetChecked() == true then
         for i=1, 40 do
-          tempName,_,_,_,tempClass = GetRaidRosterInfo(i)
+          tempName,_,_,_,_,tempClass = GetRaidRosterInfo(i)
           if tempName and tempName == v.player then
             tinsert(core.WorkingTable, v)
           end

--- a/TableFunctions.lua
+++ b/TableFunctions.lua
@@ -195,7 +195,7 @@ local function ViewLimited(raid, standby, raiders)
       for k,v in pairs(MonDKP_DKPTable) do
         if type(v) == "table" then
           for i=1, 40 do
-            tempName,_,_,_,tempClass = GetRaidRosterInfo(i)
+            tempName,_,_,_,_,tempClass = GetRaidRosterInfo(i)
             if tempName and tempName == v.player then
               tinsert(tempTable, v)
             end

--- a/TableFunctions.lua
+++ b/TableFunctions.lua
@@ -665,11 +665,11 @@ function MonDKP:SeedVerify_Update()
   if IsInGuild() then
     local leader = MonDKP:GetGuildRankGroup(1)
     
-    if leader[1].note == "" or not tonumber(leader[1].note) then    -- zeros out note if no note has been created yet
-      leader[1].note = 0
+    if leader[1].seed == "" or not tonumber(leader[1].seed) then    -- zeros out seed if no seed has been created yet
+      leader[1].seed = 0
     end
 
-    if MonDKP_DKPTable.seed >= tonumber(leader[1].note) and MonDKP_Loot.seed >= tonumber(leader[1].note) and MonDKP_DKPHistory.seed >= tonumber(leader[1].note) then         -- tonumber(leader[1].note)      in place of 0
+    if MonDKP_DKPTable.seed >= leader[1].seed and MonDKP_Loot.seed >= leader[1].seed and MonDKP_DKPHistory.seed >= leader[1].seed then
       core.UpToDate = true;
       MonDKP.DKPTable.SeedVerifyIcon:SetTexture("Interface\\AddOns\\MonolithDKP\\Media\\Textures\\up-to-date")
       MonDKP.DKPTable.SeedVerify:SetScript("OnEnter", function(self)


### PR DESCRIPTION
locale neutral tag used.
utc-based timing for seeds.
also, all seeds are named as seeds now, and all time() calls for the time are stashed in curTime.

master-seed is now appended to GM note, and not replacing it.