### PR TITLE
Add support for `!bid min`  and `!bid max`

### DIFF
--- a/Modules/Bidding.lua
+++ b/Modules/Bidding.lua
@@ -146,6 +146,11 @@ function MonDKP_CHAT_MSG_WHISPER(text, ...)
 				SendChatMessage(response, "WHISPER", nil, name)
 				return
 			end
+			if cmd == "max" then
+				cmd = dkp or cmd
+			elseif cmd == "min" then
+				cmd = core.BiddingWindow.minBid:GetNumber() or cmd
+			end
 			if (tonumber(cmd) and (MonDKP_DB.modes.MaximumBid == nil or tonumber(cmd) <= MonDKP_DB.modes.MaximumBid or MonDKP_DB.modes.MaximumBid == 0)) or ((mode == "Static Item Values" or (mode == "Zero Sum" and MonDKP_DB.modes.ZeroSumBidType == "Static")) and not cmd) then
 				if dkp then
 					if (cmd and cmd <= dkp) or (MonDKP_DB.modes.SubZeroBidding == true and dkp >= 0) or (MonDKP_DB.modes.SubZeroBidding == true and MonDKP_DB.modes.AllowNegativeBidders == true) or (mode == "Static Item Values" and dkp > 0 and (dkp > core.BiddingWindow.cost:GetNumber() or MonDKP_DB.modes.SubZeroBidding == true or MonDKP_DB.modes.costvalue == "Percent")) or ((mode == "Zero Sum" and MonDKP_DB.modes.ZeroSumBidType == "Static") and not cmd) then


### PR DESCRIPTION
Add two shortcuts for bidding the minimum amount of dkp accepted for an item, and all of a players dkp for an item:
- `!bid min`
- `!bid max`