### PR TITLE
Change CSV export to follow RFC 4180

### DIFF
--- a/Modules/exportDKP.lua
+++ b/Modules/exportDKP.lua
@@ -83,11 +83,11 @@ local function GenerateDKPTables(table, format)
 			for i=1, numrows do
 				local PlayerString = strsub(MonDKP_DKPHistory[i].players, 1, -2)
 
-					if i == numrows then
-						ExportString = ExportString.."\""..PlayerString.."\""..","..MonDKP_DKPHistory[i].dkp..","..MonDKP_DKPHistory[i].date..",".."\""..MonDKP_DKPHistory[i].reason.."\"";
-					else
-						ExportString = ExportString.."\""..PlayerString.."\""..","..MonDKP_DKPHistory[i].dkp..","..MonDKP_DKPHistory[i].date..",".."\""..MonDKP_DKPHistory[i].reason.."\"".."\n";
-					end
+				if i == numrows then
+					ExportString = ExportString.."\""..PlayerString.."\""..","..MonDKP_DKPHistory[i].dkp..","..MonDKP_DKPHistory[i].date..",".."\""..MonDKP_DKPHistory[i].reason.."\"";
+				else
+					ExportString = ExportString.."\""..PlayerString.."\""..","..MonDKP_DKPHistory[i].dkp..","..MonDKP_DKPHistory[i].date..",".."\""..MonDKP_DKPHistory[i].reason.."\"".."\n";
+				end
 			end
 		elseif table == MonDKP_Loot then
 			local numrows;

--- a/Modules/exportDKP.lua
+++ b/Modules/exportDKP.lua
@@ -60,7 +60,8 @@ local function GenerateDKPTables(table, format)
 		end
 	elseif format == "CSV" then
 		if table == MonDKP_DKPTable then
-			ExportString = "player, class, DKP, previousDKP, lifetimeGained, lifetimeSpent\n"
+			Headers = "player,class,DKP,previousDKP,lifetimeGained,lifetimeSpent\n"
+			ExportString = Headers.."";
 			for i=1, #MonDKP_DKPTable do
 				if i == #MonDKP_DKPTable then
 					ExportString = ExportString..MonDKP_DKPTable[i].player..","..MonDKP_DKPTable[i].class..","..MonDKP_DKPTable[i].dkp..","..MonDKP_DKPTable[i].previous_dkp..","..MonDKP_DKPTable[i].lifetime_gained..","..MonDKP_DKPTable[i].lifetime_spent;
@@ -77,17 +78,16 @@ local function GenerateDKPTables(table, format)
 				numrows = #MonDKP_DKPHistory
 			end
 
-			ExportString = "Listed As: PlayerString(separated by -),dkp,date(epoch),reason,...\n"
-			ExportString = ExportString.."DKPHistory = ";
+			Headers = "player,DKP,date,reason\n"
+			ExportString = Headers.."";
 			for i=1, numrows do
-				local PlayerString = gsub(MonDKP_DKPHistory[i].players, ",", "-")
-				PlayerString = strsub(PlayerString, 1, -2)
+				local PlayerString = strsub(MonDKP_DKPHistory[i].players, 1, -2)
 
-				if i == numrows then
-					ExportString = ExportString..PlayerString..","..MonDKP_DKPHistory[i].dkp..","..MonDKP_DKPHistory[i].date..","..MonDKP_DKPHistory[i].reason;
-				else
-					ExportString = ExportString..PlayerString..","..MonDKP_DKPHistory[i].dkp..","..MonDKP_DKPHistory[i].date..","..MonDKP_DKPHistory[i].reason..",";
-				end
+					if i == numrows then
+						ExportString = ExportString.."\""..PlayerString.."\""..","..MonDKP_DKPHistory[i].dkp..","..MonDKP_DKPHistory[i].date..",".."\""..MonDKP_DKPHistory[i].reason.."\"";
+					else
+						ExportString = ExportString.."\""..PlayerString.."\""..","..MonDKP_DKPHistory[i].dkp..","..MonDKP_DKPHistory[i].date..",".."\""..MonDKP_DKPHistory[i].reason.."\"".."\n";
+					end
 			end
 		elseif table == MonDKP_Loot then
 			local numrows;
@@ -98,17 +98,17 @@ local function GenerateDKPTables(table, format)
 				numrows = #MonDKP_Loot
 			end
 			
-			ExportString = "Listed As: player,itemName,itemNumber,zone,boss,date,cost,...\n"
-			ExportString = ExportString.."LootHistory = ";
+			Headers = "player,itemName,itemNumber,zone,boss,date,cost\n"
+			ExportString = Headers.."";
 			for i=1, numrows do
 				local cur = MonDKP_Loot[i].loot
 				local itemNumber = strsub(cur, string.find(cur, "Hitem:")+6, string.find(cur, ":", string.find(cur, "Hitem:")+6)-1)
 				local itemName = strsub(cur, string.find(cur, "::|h%[")+5, string.find(cur, "%]", string.find(cur, "::|h%[")+5)-1)
 				
 				if i == numrows then
-					ExportString = ExportString..MonDKP_Loot[i].player..","..itemName..","..itemNumber..","..MonDKP_Loot[i].zone..","..MonDKP_Loot[i].boss..","..MonDKP_Loot[i].date..","..MonDKP_Loot[i].cost;
+					ExportString = ExportString..MonDKP_Loot[i].player..",".."\""..itemName.."\""..","..itemNumber..",".."\""..MonDKP_Loot[i].zone.."\""..","..MonDKP_Loot[i].boss..","..MonDKP_Loot[i].date..","..MonDKP_Loot[i].cost;
 				else
-					ExportString = ExportString..MonDKP_Loot[i].player..","..itemName..","..itemNumber..","..MonDKP_Loot[i].zone..","..MonDKP_Loot[i].boss..","..MonDKP_Loot[i].date..","..MonDKP_Loot[i].cost..",";
+					ExportString = ExportString..MonDKP_Loot[i].player..",".."\""..itemName.."\""..","..itemNumber..",".."\""..MonDKP_Loot[i].zone.."\""..","..MonDKP_Loot[i].boss..","..MonDKP_Loot[i].date..","..MonDKP_Loot[i].cost.."\n";
 				end
 			end
 		end


### PR DESCRIPTION
As RFC 4180 specifies, "Spaces are considered part of a field and should not be ignored." (https://tools.ietf.org/html/rfc4180#section-2). Currently, all the headers for the CSV export are separated by a comma followed by a space, which would then become part of the header, example: `player` header on the standard DKP export would turn into `_player` with the _ indicating an empty space. 

I don't quite like the way the history is exported either, with all the names grouped up together. It makes sense performance wise, but doesn't quite fit into how CSV would be used once its exported. For now I changed the dash separation to comma separation, so that it follows the same format as HTML and XML.

I also changed some of the headers to be more uniform for all 3 different CSV exports.